### PR TITLE
Fix GDScript example image on case sensitive file systems

### DIFF
--- a/godot-3-presentation/slides/de.gd
+++ b/godot-3-presentation/slides/de.gd
@@ -65,7 +65,7 @@ var intro = [
 	},
 	{
 		"title": "GDScript Beispiel",
-		'picture': 'res://slides/img/GDScript-example.png'
+		'picture': 'res://slides/img/gdscript-example.png'
 	}
 ]
 

--- a/godot-3-presentation/slides/en.gd
+++ b/godot-3-presentation/slides/en.gd
@@ -65,7 +65,7 @@ var intro = [
 	},
 	{
 		"title": "GDScript example",
-		'picture': 'res://slides/img/GDScript-example.png'
+		'picture': 'res://slides/img/gdscript-example.png'
 	}
 ]
 

--- a/godot-3-presentation/slides/es.gd
+++ b/godot-3-presentation/slides/es.gd
@@ -65,7 +65,7 @@ var intro = [
 	},
 	{
 		"title": "Ejemplo de GDScript",
-		'picture': 'res://slides/img/GDScript-example.png'
+		'picture': 'res://slides/img/gdscript-example.png'
 	}
 ]
 

--- a/godot-3-presentation/slides/fr.gd
+++ b/godot-3-presentation/slides/fr.gd
@@ -66,7 +66,7 @@ var intro = [
 	},
 	{
 		"title": "Exemple de GDScript",
-		'picture': 'res://slides/img/GDScript-example.png'
+		'picture': 'res://slides/img/gdscript-example.png'
 	}
 ]
 

--- a/godot-3-presentation/slides/it.gd
+++ b/godot-3-presentation/slides/it.gd
@@ -65,7 +65,7 @@ var intro = [
 	},
 	{
 		"title": "Esempio di GDScript",
-		'picture': 'res://slides/img/GDScript-example.png'
+		'picture': 'res://slides/img/gdscript-example.png'
 	}
 ]
 
@@ -153,7 +153,7 @@ var concepts = [
 			Ogni nodo [color=%s]eredita[/color] da nodi di base: tutti i nodi funzionano più o meno allo stesso modo.
 			""" % [GREEN, BLUE, PINK],
 		'picture': 'res://slides/img/node-tree-2.png',
-		'footer': '*Incapsulato se lo vediamo da una prospettiva orientata all' oggetto.\n Questo design ti aiuta a strutturare le scene in modo che riflettano il tuo design di gioco.'
+		'footer': '*Incapsulato se lo vediamo da una prospettiva orientata all oggetto.\n Questo design ti aiuta a strutturare le scene in modo che riflettano il tuo design di gioco.'
 	},
 	{
 		"title": "Godot è 'un gioco fatto con Godot'",


### PR DESCRIPTION
Fixed wrong capitalization, which prevented the GDScript example image from being displayed on case sensitive systems.

Plus, there was also a stray (I think) apostrophe in an apostrophe enclosed string, which stopped the presentation from working altogether in the Italian translation. If, on the other hand, the apostrophe is supposed to be there, it needs to be escaped.